### PR TITLE
Bumped Keycloak adapter to newest version to match server version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mui/x-date-pickers": "^6.14.0",
         "envalid": "^7.3.1",
         "jotai": "^2.4.1",
-        "keycloak-js": "^19.0.2",
+        "keycloak-js": "^25.0.1",
         "localized-strings": "^0.2.4",
         "luxon": "^3.4.4",
         "react": "^18.2.0",
@@ -2005,6 +2005,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2998,9 +2999,9 @@
       }
     },
     "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
+      "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3048,13 +3049,21 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keycloak-js": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-19.0.3.tgz",
-      "integrity": "sha512-mzCBxrzfl+vB551Q7MB+T9+40IHU4i0a6g1eTatzeEGrQMis5m/BqvPC3kxTsI+/LxHbB9XYQE3u9SlWKDHQCw==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-25.0.1.tgz",
+      "integrity": "sha512-ns5sKQ5Iz3UyVGIKq2XBBXNZTlTCg9bzybR+JB2Vn+fDHIo9EGgAY4kzrBWMwbeFuegY+qJwGs05N+W9jgY9tg==",
       "dependencies": {
-        "base64-js": "^1.5.1",
-        "js-sha256": "^0.9.0"
+        "js-sha256": "^0.11.0",
+        "jwt-decode": "^4.0.0"
       }
     },
     "node_modules/lines-and-columns": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@mui/x-date-pickers": "^6.14.0",
     "envalid": "^7.3.1",
     "jotai": "^2.4.1",
-    "keycloak-js": "^19.0.2",
+    "keycloak-js": "^25.0.1",
     "localized-strings": "^0.2.4",
     "luxon": "^3.4.4",
     "react": "^18.2.0",


### PR DESCRIPTION
Resolves #149 

Apparently Keycloak JS adapter has somewhat changed during the recent Keycloak version bump from 17.X to newest, 25.0.1. This PR fixes reported issues of not being able to login to the service.