### PR TITLE
Bugfix-298-adding-slack-avatar-back

### DIFF
--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -36,13 +36,6 @@ const NavBar = () => {
   const setError = useSetAtom(errorAtom);
   const { slackAvatarsApi } = useLambdasApi();
   const navigate = useNavigate();
-  // NOTE: The Person type cannot be used here because it was previously imported from the removed timebank client.
-  // const loggedInPerson = persons.find(
-  //   (person: Person) =>
-  //     person.id === config.person.forecastUserIdOverride || person.keycloakId === userProfile?.id
-  // );
-  // const loggedInPersonAvatar =
-  //   avatars.find((avatar) => loggedInPerson?.id === avatar.personId)?.imageOriginal || "";
   const loggedInUserId = userProfile?.id;
   const loggedInPersonAvatar =
     avatars.find((avatar) => avatar.personId === loggedInUserId)?.imageOriginal || "";


### PR DESCRIPTION
## What has been done
- Replaced the removed timebank-client logic by using `UsersAvatars` data from homeLambdasClient to display the Slack image in the navbar for the logged-in user.