### PR TITLE
fix sonarqube warnings

### DIFF
--- a/src/components/questionnaire/questionnaires-edit-mode.tsx
+++ b/src/components/questionnaire/questionnaires-edit-mode.tsx
@@ -90,9 +90,7 @@ const QuestionnairesEditMode = ({ questionnaire }: Props) => {
       return false;
     }
 
-    const hasEmptyLabel = question.answerOptions.some(
-      (option) => !option.label || !option.label.trim()
-    );
+    const hasEmptyLabel = question.answerOptions.some((option) => !option.label?.trim());
     if (hasEmptyLabel) {
       return false;
     }
@@ -232,9 +230,7 @@ const QuestionnairesEditMode = ({ questionnaire }: Props) => {
     if (!questionText.trim() || !answerOptions || answerOptions.length === 0) {
       return;
     }
-    const validAnswerOptions = answerOptions.filter(
-      (option) => option.label && option.label.trim()
-    );
+    const validAnswerOptions = answerOptions.filter((option) => option.label?.trim());
 
     if (validAnswerOptions.length === 0) {
       return;

--- a/src/components/wiki-documentation/rich-text-editor/plugins/toolbar-plugin.tsx
+++ b/src/components/wiki-documentation/rich-text-editor/plugins/toolbar-plugin.tsx
@@ -27,7 +27,6 @@ import {
   FORMAT_TEXT_COMMAND,
   type TextFormatType
 } from "lexical";
-import type { ReactJSXElement } from "node_modules/@emotion/react/types/jsx-namespace";
 import { useEffect, useMemo, useState } from "react";
 import { useLambdasApi } from "src/hooks/use-api";
 import strings from "src/localization/strings";
@@ -39,7 +38,7 @@ const colors = wikiScreenColors;
 
 interface TextCommand {
   key: string;
-  icon: ReactJSXElement;
+  icon: React.JSX.Element;
   handler: () => void;
 }
 

--- a/src/utils/vacation-status-utils.ts
+++ b/src/utils/vacation-status-utils.ts
@@ -24,10 +24,9 @@ export const getVacationRequestStatusColor = (vacationRequestStatus: VacationReq
 export const getTotalVacationRequestStatus = (statuses: VacationRequestStatus[]) => {
   if (statuses.some((status) => status.status === VacationRequestStatuses.APPROVED)) {
     return VacationRequestStatuses.APPROVED;
-  }
-  if (statuses.some((status) => status.status === VacationRequestStatuses.DECLINED)) {
+  } else if (statuses.some((status) => status.status === VacationRequestStatuses.DECLINED)) {
     return VacationRequestStatuses.DECLINED;
+  } else {
+    return VacationRequestStatuses.PENDING;
   }
-
-  return VacationRequestStatuses.PENDING;
 };


### PR DESCRIPTION
Fixed 4/5 warnings that SonarQube gave earlier. One of them is more complicated: Do not use Array index in keys. It would be better to use id, except that there is no id. Fixing this might be a bigger issue, so it was left for now. 