### PR TITLE
bugfix-369-questionnaire-mouse-pointer

### DIFF
--- a/src/components/questionnaire/questionnaire-table.tsx
+++ b/src/components/questionnaire/questionnaire-table.tsx
@@ -418,10 +418,12 @@ const QuestionnaireTable = () => {
           sx={{
             margin: 0,
             "& .MuiDataGrid-cell": {
-              padding: "8px"
+              padding: "8px",
+              cursor: "pointer"
             },
             "& .MuiDataGrid-columnHeader": {
-              padding: "0 8px"
+              padding: "0 8px",
+              cursor: "pointer"
             }
           }}
           rows={filteredQuestionnaires}


### PR DESCRIPTION
pointer now changed to hand when mousing over questionnaires to show that they are clickable elements