### PR TITLE
Error message improvement

### DIFF
--- a/src/components/home/balance-card.tsx
+++ b/src/components/home/balance-card.tsx
@@ -64,8 +64,9 @@ const BalanceCard = () => {
         userId: severaUserId
       });
       setUsersFlextime(fetchedUsersFlextime);
-    } catch (error) {
-      setError(`${strings.error.fetchFailedFlextime}, ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error.response.json();
+      setError(`${strings.error.fetchFailedFlextime}: ${errorMessage.message}`);
     } finally {
       setLoading(false);
     }
@@ -139,9 +140,7 @@ const BalanceCard = () => {
             <Grid style={{ marginBottom: 1 }} size={1}>
               <ScheduleIcon style={{ marginTop: 1 }} />
             </Grid>
-            <Grid size={11}>
-              {loading ? <Skeleton /> : renderUserFlextime()}
-            </Grid>
+            <Grid size={11}>{loading ? <Skeleton /> : renderUserFlextime()}</Grid>
           </Grid>
         </CardContent>
       </Card>

--- a/src/components/home/oncall-card.tsx
+++ b/src/components/home/oncall-card.tsx
@@ -30,8 +30,9 @@ const OnCallCard = () => {
     try {
       const fetchedData = await onCallApi.listOnCallData({ year: year.toString() });
       setOnCallData(fetchedData);
-    } catch (error) {
-      setError(`${strings.oncall.fetchFailed}, ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error.response.json();
+      setError(`${strings.oncall.fetchFailed}: ${errorMessage.message}`);
     }
   };
 

--- a/src/components/home/questionnaire-progress.tsx
+++ b/src/components/home/questionnaire-progress.tsx
@@ -25,8 +25,9 @@ const QuestionnaireProgress = () => {
       try {
         const response = await questionnairesApi.listQuestionnaires();
         setQuestionnaires(response);
-      } catch (error) {
-        console.error("Failed to fetch questionnaires:", error);
+      } catch (error: any) {
+        const errorMessage = await error.response.json();
+        setError(`${strings.error.fetchFailedQuestionnaires}: ${errorMessage.message}`);
       } finally {
         setLoading(false);
       }
@@ -63,3 +64,6 @@ const QuestionnaireProgress = () => {
 };
 
 export default QuestionnaireProgress;
+function setError(arg0: string) {
+  throw new Error("Function not implemented.");
+}

--- a/src/components/home/questionnaire-progress.tsx
+++ b/src/components/home/questionnaire-progress.tsx
@@ -1,7 +1,8 @@
 import { Box, CircularProgress, Typography } from "@mui/material";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect, useState } from "react";
 import { userProfileAtom } from "src/atoms/auth";
+import { errorAtom } from "src/atoms/error";
 import { usersAtom } from "src/atoms/user";
 import type { Questionnaire, User } from "src/generated/homeLambdasClient";
 import { useLambdasApi } from "src/hooks/use-api";
@@ -19,7 +20,7 @@ const QuestionnaireProgress = () => {
   const [loading, setLoading] = useState(false);
 
   const loggedInUser = users.find((user: User) => user.id === userProfile?.id);
-
+  const setError = useSetAtom(errorAtom);
   useEffect(() => {
     const fetchQuestionnaires = async () => {
       try {
@@ -64,6 +65,3 @@ const QuestionnaireProgress = () => {
 };
 
 export default QuestionnaireProgress;
-function setError(arg0: string) {
-  throw new Error("Function not implemented.");
-}

--- a/src/components/home/software-registry-card.tsx
+++ b/src/components/home/software-registry-card.tsx
@@ -27,8 +27,9 @@ const SoftwareRegistryCard = () => {
     try {
       const fetchedApplications = await softwareApi.listSoftware();
       setApplications(fetchedApplications);
-    } catch (error) {
-      setError(`Error fetching software data: ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error.response.json();
+      setError(`${strings.error.fetchFailedSoftwareData}: ${errorMessage}`);
     } finally {
       setLoading(false);
     }

--- a/src/components/home/sprint-view-card-content/user-sprint-view-card.tsx
+++ b/src/components/home/sprint-view-card-content/user-sprint-view-card.tsx
@@ -52,8 +52,11 @@ const SprintViewCardContent = () => {
 
         setResourceAllocations(fetchedResourceAllocations);
         setWorkHours(fetchedWorkHours);
-      } catch (error) {
-        setError(`${strings.sprintRequestError.fetchResourceAllocationsError}, ${error}`);
+      } catch (error: any) {
+        const errorMessage = await error.response.json();
+        setError(
+          `${strings.sprintRequestError.fetchResourceAllocationsError}, ${errorMessage.message}`
+        );
       }
     }
     setLoading(false);

--- a/src/components/home/vacations-card.tsx
+++ b/src/components/home/vacations-card.tsx
@@ -52,8 +52,9 @@ const VacationsCard = () => {
         ? await vacationRequestsApi.listVacationRequests({})
         : await vacationRequestsApi.listVacationRequests({ userId: loggedInUser.id });
       setVacationRequests(fetchedVacationRequests);
-    } catch (error) {
-      setError(`${strings.vacationRequestError.fetchRequestError}, ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error.response.json();
+      setError(`${strings.vacationRequestError.fetchRequestError}, ${errorMessage.message}`);
     } finally {
       setLoading(false);
     }

--- a/src/components/home/wiki-documentation-card.tsx
+++ b/src/components/home/wiki-documentation-card.tsx
@@ -51,8 +51,8 @@ const WikiDocumentationCard = () => {
       setLastUpdatedArticle(fetchedArticles[0]);
       setArticlesAtom(fetchedArticles);
     } catch (error: any) {
-      const message = (await error.response.json()).message;
-      setError(message);
+      const errorMessage = await error.response.json();
+      setError(`${strings.error.fetchFailedWikiArticles}: ${errorMessage.message}`);
     }
     setLoading(false);
   };
@@ -92,7 +92,8 @@ const WikiDocumentationCard = () => {
               sm: 12,
               md: 5,
               lg: 4
-            }}>
+            }}
+          >
             <Box
               component="img"
               sx={{
@@ -123,7 +124,8 @@ const WikiDocumentationCard = () => {
               sm: 12,
               md: 7,
               lg: 8
-            }}>
+            }}
+          >
             <Typography
               variant="h6"
               sx={{

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -85,8 +85,9 @@ const NavBar = () => {
         email: encodedEmail
       });
       setAvatars({ image_original: fetchedAvatars.imageOriginal });
-    } catch (error) {
-      setError(`${strings.error.fetchSlackAvatarsFailed}: ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error.response?.json();
+      setError(`${strings.error.fetchSlackAvatarsFailed}: ${errorMessage?.message}`);
     }
   };
 

--- a/src/components/onCall/oncall-list-view.tsx
+++ b/src/components/onCall/oncall-list-view.tsx
@@ -52,8 +52,9 @@ const OnCallListView = ({ selectedDate, setSelectedDate, updatePaidStatus }: Pro
   const handleCheckboxChange = async (week: number, currentPaid: boolean) => {
     try {
       await updatePaidStatus(selectedDate.year, week, currentPaid);
-    } catch {
-      setError(strings.oncall.errorUpdatingPaidStatus);
+    } catch (error: any) {
+      const errorMessage = await error.response?.json();
+      setError(`${strings.oncall.errorUpdatingPaidStatus}: ${errorMessage?.message}`);
     }
   };
 

--- a/src/components/providers/authentication-provider.tsx
+++ b/src/components/providers/authentication-provider.tsx
@@ -3,8 +3,10 @@ import Keycloak from "keycloak-js";
 import { type ReactNode, useCallback, useEffect } from "react";
 import config from "src/app/config";
 import { authAtom, userProfileAtom } from "src/atoms/auth";
+import { errorAtom } from "src/atoms/error";
 import { usersAtom } from "src/atoms/user";
 import { useLambdasApi } from "src/hooks/use-api";
+import strings from "src/localization/strings";
 
 interface Props {
   children: ReactNode;
@@ -19,6 +21,7 @@ const AuthenticationProvider = ({ children }: Props) => {
   const [auth, setAuth] = useAtom(authAtom);
   const setUserProfile = useSetAtom(userProfileAtom);
   const setUsers = useSetAtom(usersAtom);
+  const setError = useSetAtom(errorAtom);
   const { usersApi } = useLambdasApi();
 
   const updateAuthData = useCallback(() => {
@@ -51,8 +54,9 @@ const AuthenticationProvider = ({ children }: Props) => {
       keycloak.onAuthSuccess = async () => {
         try {
           await keycloak.loadUserProfile();
-        } catch (error) {
-          console.error("Could not load user profile", error);
+        } catch (error: any) {
+          const errorMessage = await error?.response?.json();
+          setError(`${strings.error.loadUserProfileFailed}: ${errorMessage?.message || error}`);
         }
 
         updateAuthData();

--- a/src/components/questionnaire/new-questionnaire-builder.tsx
+++ b/src/components/questionnaire/new-questionnaire-builder.tsx
@@ -176,8 +176,9 @@ const NewQuestionnaireBuilder = () => {
       closeAndClear();
       navigate(-1);
       return createdQuestionnaire;
-    } catch (error) {
-      setError(`${strings.error.questionnaireSaveFailed}, ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.questionnaireSaveFailed}: ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
     }
@@ -347,7 +348,6 @@ const NewQuestionnaireBuilder = () => {
                 <Box>
                   <Button
                     sx={{ display: "flex", alignItems: "center", mt: 6, mr: 4 }}
-                    id="save-submit"
                     size="large"
                     variant="contained"
                     color="success"

--- a/src/components/questionnaire/questionnaire-manager.tsx
+++ b/src/components/questionnaire/questionnaire-manager.tsx
@@ -72,8 +72,9 @@ const QuestionnaireManager = ({ mode }: Props) => {
       try {
         const fetchedQuestionnaire = await questionnairesApi.getQuestionnairesById({ id });
         setQuestionnaire(fetchedQuestionnaire);
-      } catch (error) {
-        setError(`${strings.error.questionnaireLoadFailed}, ${error}`);
+      } catch (error: any) {
+        const errorMessage = await error?.response?.json();
+        setError(`${strings.error.questionnaireLoadFailed}: ${errorMessage?.message || error}`);
       }
       setLoading(false);
     };
@@ -171,8 +172,9 @@ const QuestionnaireManager = ({ mode }: Props) => {
         );
         setQuestionnaireFeedbackDialogOpen(true);
         return passedQuestionnaire;
-      } catch (error) {
-        setError(`${strings.error.questionnaireSaveFailed}, ${error}`);
+      } catch (error: any) {
+        const errorMessage = await error?.response?.json();
+        setError(`${strings.error.questionnaireSaveFailed}: ${errorMessage?.message || error}`);
       }
     } else {
       setQuestionnaireFeedbackMessage(

--- a/src/components/questionnaire/questionnaire-table.tsx
+++ b/src/components/questionnaire/questionnaire-table.tsx
@@ -71,8 +71,9 @@ const QuestionnaireTable = () => {
 
         setQuestionnaires(processedQuestionnaires);
         setFilteredQuestionnaires(processedQuestionnaires);
-      } catch (error) {
-        setError(`${strings.error.questionnaireLoadFailed}, ${error}`);
+      } catch (error: any) {
+        const errorMessage = await error?.response?.json();
+        setError(`${strings.error.questionnaireLoadFailed}: ${errorMessage?.message || error}`);
       }
       setLoading(false);
     };
@@ -175,8 +176,9 @@ const QuestionnaireTable = () => {
         prevQuestionnaires.filter((questionnaire) => questionnaire.id !== deleteId)
       );
       handleCloseDialog();
-    } catch (error) {
-      setError(`${strings.error.questionnaireDeleteFailed}, ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.questionnaireDeleteFailed}: ${errorMessage?.message || error}`);
     }
     setLoading(false);
   };

--- a/src/components/questionnaire/questionnaires-edit-mode.tsx
+++ b/src/components/questionnaire/questionnaires-edit-mode.tsx
@@ -307,8 +307,9 @@ const QuestionnairesEditMode = ({ questionnaire }: Props) => {
       });
       setSnackbarOpen(true);
       return updatedQuestionnaire;
-    } catch (error) {
-      setError(`${strings.error.questionnaireUpdateFailed}, ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.questionnaireUpdateFailed}: ${errorMessage?.message || error}`);
     }
     setLoading(false);
   };

--- a/src/components/screens/admin-vacation-management/admin-vacation-management-screen.tsx
+++ b/src/components/screens/admin-vacation-management/admin-vacation-management-screen.tsx
@@ -69,8 +69,8 @@ const AdminVacationManagementScreen = () => {
         setLoadingUsers(true);
         const fetchedUsers = await usersApi.listUsers();
         setUsers(fetchedUsers);
-      } catch (error) {
-        const errorMessage = await (error as any)?.response?.json();
+      } catch (error:any) {
+        const errorMessage = await error?.response?.json();
         setError(`${strings.vacationRequestError.failedToLoad}: ${errorMessage?.message || error}`);
       } finally {
         setLoadingUsers(false);
@@ -195,8 +195,8 @@ const AdminVacationManagementScreen = () => {
       );
 
       handleCloseDialog();
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error:any) {
+      const errorMessage = await error?.response?.json();
       setError(`${strings.vacationRequestError.failedToLoad}: ${errorMessage?.message || error}`);
     } finally {
       setSaving(false);

--- a/src/components/screens/admin-vacation-management/admin-vacation-management-screen.tsx
+++ b/src/components/screens/admin-vacation-management/admin-vacation-management-screen.tsx
@@ -70,7 +70,8 @@ const AdminVacationManagementScreen = () => {
         const fetchedUsers = await usersApi.listUsers();
         setUsers(fetchedUsers);
       } catch (error) {
-        setError(`${strings.vacationRequestError.failedToLoad}, ${error}`);
+        const errorMessage = await (error as any)?.response?.json();
+        setError(`${strings.vacationRequestError.failedToLoad}: ${errorMessage?.message || error}`);
       } finally {
         setLoadingUsers(false);
       }
@@ -195,7 +196,8 @@ const AdminVacationManagementScreen = () => {
 
       handleCloseDialog();
     } catch (error) {
-      setError(`${strings.vacationRequestError.failedToLoad}, ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(`${strings.vacationRequestError.failedToLoad}: ${errorMessage?.message || error}`);
     } finally {
       setSaving(false);
     }

--- a/src/components/screens/all-software-screen.tsx
+++ b/src/components/screens/all-software-screen.tsx
@@ -86,8 +86,9 @@ const AllSoftwareScreen = () => {
     try {
       const fetchedApplications = await softwareApi.listSoftware();
       setApplications(fetchedApplications);
-    } catch (error) {
-      setError(`Error fetching software data: ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.softwareFetchFailed} ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
     }
@@ -184,8 +185,9 @@ const AllSoftwareScreen = () => {
           softwareRegistry: updatedApp
         });
       }
-    } catch (error) {
-      setError(`Error updating status: ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.softwareStatusUpdateFailed} ${errorMessage?.message || error}`);
     }
   };
 
@@ -219,8 +221,9 @@ const AllSoftwareScreen = () => {
           users: updatedUsers
         }
       });
-    } catch (error) {
-      setError(`Error saving the app: ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.softwareSaveFailed} ${errorMessage?.message || error}`);
     }
   };
 
@@ -260,8 +263,9 @@ const AllSoftwareScreen = () => {
       setApplications(updatedApplications);
 
       await softwareApi.deleteSoftwareById({ id: selectedApplicationId });
-    } catch (error) {
-      setError(`Error deleting the app: ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.softwareDeleteFailed} ${errorMessage?.message || error}`);
     } finally {
       closeDeleteDialog();
     }

--- a/src/components/screens/employee-flextime-screen.tsx
+++ b/src/components/screens/employee-flextime-screen.tsx
@@ -53,8 +53,9 @@ const EmployeeFlextimeScreen = () => {
     try {
       const data = await resourceAllocationsApi.listUsersFlextime();
       setUsersFlextime(data);
-    } catch (err) {
-      setError(`${strings.error.fetchFailedFlextime}, ${err}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.fetchFailedFlextime}: ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
     }

--- a/src/components/screens/on-call-calendar-screen.tsx
+++ b/src/components/screens/on-call-calendar-screen.tsx
@@ -77,9 +77,10 @@ const OnCallCalendarScreen = () => {
     try {
       const fetchedData = await onCallApi.listOnCallData({ year: year.toString() });
       setOnCallData(fetchedData);
-    } catch (error) {
+    } catch (error: any) {
       if (!(error instanceof SyntaxError)) {
-        setError(`${strings.oncall.fetchFailed} ${error}`);
+        const errorMessage = await error?.response?.json();
+        setError(`${strings.oncall.fetchFailed}: ${errorMessage?.message || error}`);
       }
       setOnCallData([]);
     } finally {
@@ -97,8 +98,9 @@ const OnCallCalendarScreen = () => {
       const fetchedData = await onCallApi.listOnCallData({ year: currentYear.toString() });
       const currentOnCallPerson = fetchedData.find((item) => item.week === currentWeek)?.username;
       setOnCallPerson(currentOnCallPerson ?? undefined);
-    } catch (error) {
-      setError(`${strings.oncall.fetchFailed} ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.oncall.fetchFailed}: ${errorMessage?.message || error}`);
     }
   };
 
@@ -122,8 +124,9 @@ const OnCallCalendarScreen = () => {
           item.year === year && item.week === weekNumber ? { ...item, paid: !paid } : item
         )
       );
-    } catch (error) {
-      setError(`${strings.oncall.errorUpdatingPaidStatus}, ${error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.oncall.errorUpdatingPaidStatus}: ${errorMessage?.message || error}`);
     }
   };
   const theme = useTheme();

--- a/src/components/screens/settings-screen.tsx
+++ b/src/components/screens/settings-screen.tsx
@@ -73,8 +73,9 @@ const SettingsScreen = ({ screenColorMode, setScreenColorMode }: SettingsScreenP
           prev.map((u) => (u.id === userProfile.id ? { ...u, attributes: updatedAttributes } : u))
         );
       }
-    } catch (error) {
-      setError(`${strings.error.fetchFailedSevera}, ${String(error)}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.fetchFailedSevera}: ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
     }
@@ -102,8 +103,9 @@ const SettingsScreen = ({ screenColorMode, setScreenColorMode }: SettingsScreenP
         prev.map((u) => (u.id === userProfile.id ? { ...u, attributes: updatedAttributes } : u))
       );
       setIsConsentGiven(false);
-    } catch (error) {
-      setError(`${strings.error.fetchFailedSevera}, ${String(error)}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(`${strings.error.fetchFailedSevera}: ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
     }

--- a/src/components/screens/software-registry-screen.tsx
+++ b/src/components/screens/software-registry-screen.tsx
@@ -125,8 +125,8 @@ const SoftwareScreen = () => {
     try {
       const fetchedSoftware = await softwareApi.listSoftware();
       setApplications(fetchedSoftware);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(`${strings.error.softwareRegistryFetchFailed}: ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
@@ -158,8 +158,8 @@ const SoftwareScreen = () => {
 
         setApplications((prevApps) => prevApps.map((a) => (a.id === appId ? updatedApp : a)));
       }
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(`${strings.error.softwareRegistryUpdateFailed}: ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);

--- a/src/components/screens/software-registry-screen.tsx
+++ b/src/components/screens/software-registry-screen.tsx
@@ -2,7 +2,6 @@ import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import GridViewIcon from "@mui/icons-material/GridView";
 import ListViewIcon from "@mui/icons-material/List";
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -13,9 +12,10 @@ import {
   Typography,
   useTheme
 } from "@mui/material";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { authAtom } from "src/atoms/auth";
+import { errorAtom } from "src/atoms/error";
 import { softwareAtom } from "src/atoms/software";
 import type { SoftwareRegistry } from "src/generated/homeLambdasClient";
 import { SoftwareStatus } from "src/generated/homeLambdasClient";
@@ -34,11 +34,11 @@ import Sidebar from "../software-registry/Sidebar";
 const SoftwareScreen = () => {
   const { softwareApi } = useLambdasApi();
   const auth = useAtomValue(authAtom);
+  const setError = useSetAtom(errorAtom);
   const loggedUserId = auth?.token?.sub ?? "";
   const [isGridView, setIsGridView] = useState(true);
   const [software, setApplications] = useAtom(softwareAtom);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [searchValue, setSearchValue] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -126,7 +126,8 @@ const SoftwareScreen = () => {
       const fetchedSoftware = await softwareApi.listSoftware();
       setApplications(fetchedSoftware);
     } catch (error) {
-      setError(`Error fetching software data: ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(`${strings.error.softwareRegistryFetchFailed}: ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
     }
@@ -158,7 +159,8 @@ const SoftwareScreen = () => {
         setApplications((prevApps) => prevApps.map((a) => (a.id === appId ? updatedApp : a)));
       }
     } catch (error) {
-      setError(`Error updating software: ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(`${strings.error.softwareRegistryUpdateFailed}: ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
     }
@@ -298,11 +300,6 @@ const SoftwareScreen = () => {
             />
           </Grid>
           <Grid size="grow">
-            {error && (
-              <Box mb={2} width="100%">
-                <Alert severity="error">{error}</Alert>
-              </Box>
-            )}
             {loading ? (
               <Box textAlign="center">
                 <CircularProgress size={50} sx={{ mt: 2 }} />

--- a/src/components/screens/sprint-view-screen.tsx
+++ b/src/components/screens/sprint-view-screen.tsx
@@ -101,8 +101,8 @@ const SprintViewScreen = () => {
             severaUserId
           });
       setResourceAllocations(fetchedResourceAllocations);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.sprintRequestError.fetchResourceAllocationsError}: ${errorMessage?.message || error}`
       );

--- a/src/components/screens/sprint-view-screen.tsx
+++ b/src/components/screens/sprint-view-screen.tsx
@@ -102,7 +102,10 @@ const SprintViewScreen = () => {
           });
       setResourceAllocations(fetchedResourceAllocations);
     } catch (error) {
-      setError(`${strings.sprintRequestError.fetchResourceAllocationsError}, ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.sprintRequestError.fetchResourceAllocationsError}: ${errorMessage?.message || error}`
+      );
     }
     setLoading(false);
   }, [loggedInUser, adminMode, resourceAllocationsApi, setError]);

--- a/src/components/screens/vacation-requests-screen.tsx
+++ b/src/components/screens/vacation-requests-screen.tsx
@@ -112,8 +112,8 @@ const VacationRequestsScreen = () => {
         });
       }
       setVacationRequests(fetchedVacationRequests);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.vacationRequestError.fetchRequestError}: ${errorMessage?.message || error}`
       );
@@ -158,8 +158,8 @@ const VacationRequestsScreen = () => {
       }
 
       return vacationRequest;
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.vacationRequestError.fetchRequestError}: ${errorMessage?.message || error}`
       );
@@ -187,8 +187,8 @@ const VacationRequestsScreen = () => {
             updatedVacationRequests = updatedVacationRequests.filter(
               (vacationRequest) => vacationRequest.id !== selectedRowId
             );
-          } catch (error) {
-            const errorMessage = await (error as any)?.response?.json();
+          } catch (error: any) {
+            const errorMessage = await error?.response?.json();
             setError(
               `${strings.vacationRequestError.deleteRequestError}: ${errorMessage?.message || error}`
             );
@@ -242,8 +242,8 @@ const VacationRequestsScreen = () => {
         }
       });
       setVacationRequests([createdRequest, ...vacationRequests]);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.vacationRequestError.createRequestError}: ${errorMessage?.message || error}`
       );
@@ -287,8 +287,8 @@ const VacationRequestsScreen = () => {
         }
       });
       setVacationRequests([createdRequest, ...vacationRequests]);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.vacationRequestError.createRequestError}: ${errorMessage?.message || error}`
       );
@@ -360,8 +360,8 @@ const VacationRequestsScreen = () => {
         vacationRequest.id === updatedRequest.id ? updatedRequest : vacationRequest
       );
       setVacationRequests(updatedVacationRequests);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.vacationRequestError.updateRequestError}: ${errorMessage?.message || error}`
       );
@@ -439,8 +439,8 @@ const VacationRequestsScreen = () => {
       // Refresh user data to get updated remaining vacation days.
       const updatedUser = await usersApi.findUser({ userId: loggedInUser.id });
       setUsers((prevUsers) => prevUsers.map((u) => (u.id === updatedUser.id ? updatedUser : u)));
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.vacationRequestError.updateRequestError}: ${errorMessage?.message || error}`
       );

--- a/src/components/screens/vacation-requests-screen.tsx
+++ b/src/components/screens/vacation-requests-screen.tsx
@@ -113,7 +113,10 @@ const VacationRequestsScreen = () => {
       }
       setVacationRequests(fetchedVacationRequests);
     } catch (error) {
-      setError(`${strings.vacationRequestError.fetchRequestError}, ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.vacationRequestError.fetchRequestError}: ${errorMessage?.message || error}`
+      );
     }
     setLoading(false);
   };
@@ -156,7 +159,10 @@ const VacationRequestsScreen = () => {
 
       return vacationRequest;
     } catch (error) {
-      setError(`${strings.vacationRequestError.fetchRequestError}, ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.vacationRequestError.fetchRequestError}: ${errorMessage?.message || error}`
+      );
       return null;
     } finally {
       setLoading(false);
@@ -182,7 +188,10 @@ const VacationRequestsScreen = () => {
               (vacationRequest) => vacationRequest.id !== selectedRowId
             );
           } catch (error) {
-            setError(`${strings.vacationRequestError.deleteRequestError}, ${error}`);
+            const errorMessage = await (error as any)?.response?.json();
+            setError(
+              `${strings.vacationRequestError.deleteRequestError}: ${errorMessage?.message || error}`
+            );
           }
           setLoading(false);
         })
@@ -234,7 +243,10 @@ const VacationRequestsScreen = () => {
       });
       setVacationRequests([createdRequest, ...vacationRequests]);
     } catch (error) {
-      setError(`${strings.vacationRequestError.createRequestError}, ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.vacationRequestError.createRequestError}: ${errorMessage?.message || error}`
+      );
     }
     setLoading(false);
   };
@@ -276,7 +288,10 @@ const VacationRequestsScreen = () => {
       });
       setVacationRequests([createdRequest, ...vacationRequests]);
     } catch (error) {
-      setError(`${strings.vacationRequestError.createRequestError}, ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.vacationRequestError.createRequestError}: ${errorMessage?.message || error}`
+      );
     }
     setLoading(false);
   };
@@ -346,7 +361,10 @@ const VacationRequestsScreen = () => {
       );
       setVacationRequests(updatedVacationRequests);
     } catch (error) {
-      setError(`${strings.vacationRequestError.updateRequestError}, ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.vacationRequestError.updateRequestError}: ${errorMessage?.message || error}`
+      );
     }
     setLoading(false);
   };
@@ -422,7 +440,10 @@ const VacationRequestsScreen = () => {
       const updatedUser = await usersApi.findUser({ userId: loggedInUser.id });
       setUsers((prevUsers) => prevUsers.map((u) => (u.id === updatedUser.id ? updatedUser : u)));
     } catch (error) {
-      setError(`${strings.vacationRequestError.updateRequestError}, ${error}`);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.vacationRequestError.updateRequestError}: ${errorMessage?.message || error}`
+      );
     }
     setLoading(false);
   };

--- a/src/components/software-registry/AddSoftwareModal.tsx
+++ b/src/components/software-registry/AddSoftwareModal.tsx
@@ -79,7 +79,8 @@ const AddSoftwareModal = ({
         const users = await usersApi.listUsers();
         setUserList(users);
       } catch (error) {
-        setError(`${strings.error.fetchFailedGeneral}: ${error}`);
+        const errorMessage = await (error as any)?.response?.json();
+        setError(`${strings.error.fetchFailedGeneral}: ${errorMessage?.message || error}`);
       }
     };
 
@@ -191,7 +192,8 @@ const AddSoftwareModal = ({
               size={{
                 xs: 12,
                 md: 6
-              }}>
+              }}
+            >
               <TextField
                 fullWidth
                 label={strings.softwareRegistry.name}
@@ -211,7 +213,8 @@ const AddSoftwareModal = ({
               size={{
                 xs: 12,
                 md: 6
-              }}>
+              }}
+            >
               <TextField
                 fullWidth
                 label={strings.softwareRegistry.imageURL}
@@ -226,7 +229,8 @@ const AddSoftwareModal = ({
               size={{
                 xs: 12,
                 md: 6
-              }}>
+              }}
+            >
               <TextField
                 fullWidth
                 label={strings.softwareRegistry.URLAddress}

--- a/src/components/software-registry/AddSoftwareModal.tsx
+++ b/src/components/software-registry/AddSoftwareModal.tsx
@@ -78,8 +78,8 @@ const AddSoftwareModal = ({
       try {
         const users = await usersApi.listUsers();
         setUserList(users);
-      } catch (error) {
-        const errorMessage = await (error as any)?.response?.json();
+      } catch (error: any) {
+        const errorMessage = await error?.response?.json();
         setError(`${strings.error.fetchFailedGeneral}: ${errorMessage?.message || error}`);
       }
     };

--- a/src/components/software-registry/Recommendations.tsx
+++ b/src/components/software-registry/Recommendations.tsx
@@ -86,8 +86,8 @@ const Recommendations = ({ applications, onAddUser }: RecommendationsProps) => {
       } else {
         console.warn(`User with ID ${userId} not found`);
       }
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       console.error(
         `${strings.softwareRegistry.recommendationsFetchUserFailed}: ${errorMessage?.message || error}`
       );

--- a/src/components/software-registry/Recommendations.tsx
+++ b/src/components/software-registry/Recommendations.tsx
@@ -87,7 +87,10 @@ const Recommendations = ({ applications, onAddUser }: RecommendationsProps) => {
         console.warn(`User with ID ${userId} not found`);
       }
     } catch (error) {
-      console.error("Error fetching user data:", error);
+      const errorMessage = await (error as any)?.response?.json();
+      console.error(
+        `${strings.softwareRegistry.recommendationsFetchUserFailed}: ${errorMessage?.message || error}`
+      );
     } finally {
       setLoadingStates((prev) => ({
         ...prev,

--- a/src/components/software-registry/SoftwareDetails.tsx
+++ b/src/components/software-registry/SoftwareDetails.tsx
@@ -67,8 +67,8 @@ const SoftwareDetails = () => {
     try {
       const data = await softwareApi.getSoftwareById({ id });
       setSoftware(data);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.softwareRegistry.softwareDetailsFetchFailed}: ${errorMessage?.message || (error as Error).message}`
       );
@@ -85,8 +85,8 @@ const SoftwareDetails = () => {
     try {
       const fetchedSoftware = await softwareApi.listSoftware();
       setSoftwareList(fetchedSoftware);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.softwareRegistry.errorFetchingSoftwareToList}: ${errorMessage?.message || (error as Error).message}`
       );
@@ -108,8 +108,8 @@ const SoftwareDetails = () => {
         softwareRegistry: { ...software, users: updatedUsers }
       });
       setSoftware({ ...software, users: updatedUsers });
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.softwareRegistry.softwareDetailsRemoveUserFailed}: ${errorMessage?.message || (error as Error).message}`
       );
@@ -143,8 +143,8 @@ const SoftwareDetails = () => {
         softwareRegistry: { ...software, users: updatedUsers }
       });
       setSoftware({ ...software, users: updatedUsers });
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.softwareRegistry.softwareDetailsAddUserFailed}: ${errorMessage?.message || (error as Error).message}`
       );
@@ -164,8 +164,8 @@ const SoftwareDetails = () => {
       });
       setSoftware(updatedSoftware);
       setIsEditModalOpen(false);
-    } catch (error) {
-      const errorMessage = await (error as any)?.response?.json();
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
       setError(
         `${strings.softwareRegistry.softwareDetailsUpdateFailed}: ${errorMessage?.message || (error as Error).message}`
       );

--- a/src/components/software-registry/SoftwareDetails.tsx
+++ b/src/components/software-registry/SoftwareDetails.tsx
@@ -68,7 +68,10 @@ const SoftwareDetails = () => {
       const data = await softwareApi.getSoftwareById({ id });
       setSoftware(data);
     } catch (error) {
-      setError((error as Error).message || "Error fetching software details");
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.softwareRegistry.softwareDetailsFetchFailed}: ${errorMessage?.message || (error as Error).message}`
+      );
     } finally {
       setLoading(false);
     }
@@ -83,7 +86,10 @@ const SoftwareDetails = () => {
       const fetchedSoftware = await softwareApi.listSoftware();
       setSoftwareList(fetchedSoftware);
     } catch (error) {
-      setError((error as Error).message || strings.softwareRegistry.errorFetchingSoftwareToList);
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.softwareRegistry.errorFetchingSoftwareToList}: ${errorMessage?.message || (error as Error).message}`
+      );
     } finally {
       setLoading(false);
     }
@@ -103,7 +109,10 @@ const SoftwareDetails = () => {
       });
       setSoftware({ ...software, users: updatedUsers });
     } catch (error) {
-      setError((error as Error).message || "Error removing user from software");
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.softwareRegistry.softwareDetailsRemoveUserFailed}: ${errorMessage?.message || (error as Error).message}`
+      );
     }
   };
 
@@ -135,7 +144,10 @@ const SoftwareDetails = () => {
       });
       setSoftware({ ...software, users: updatedUsers });
     } catch (error) {
-      setError((error as Error).message || "Error adding user to software");
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.softwareRegistry.softwareDetailsAddUserFailed}: ${errorMessage?.message || (error as Error).message}`
+      );
     }
   };
 
@@ -153,7 +165,10 @@ const SoftwareDetails = () => {
       setSoftware(updatedSoftware);
       setIsEditModalOpen(false);
     } catch (error) {
-      setError((error as Error).message || "Error updating software");
+      const errorMessage = await (error as any)?.response?.json();
+      setError(
+        `${strings.softwareRegistry.softwareDetailsUpdateFailed}: ${errorMessage?.message || (error as Error).message}`
+      );
     }
   };
 
@@ -252,7 +267,8 @@ const SoftwareDetails = () => {
           size={{
             xs: 12,
             md: 6
-          }}>
+          }}
+        >
           <Typography variant="h4" gutterBottom>
             {strings.softwareRegistry.description}
           </Typography>
@@ -273,7 +289,8 @@ const SoftwareDetails = () => {
           size={{
             xs: 12,
             md: 6
-          }}>
+          }}
+        >
           <Typography variant="h4" gutterBottom>
             {strings.softwareRegistry.review}
           </Typography>

--- a/src/components/sprint-view-table/tasks-table.tsx
+++ b/src/components/sprint-view-table/tasks-table.tsx
@@ -76,8 +76,8 @@ const TaskTable = ({ filter, project }: Props) => {
         setResourceAllocations(fetchedResourceAllocations);
         setWorkHours(fetchedWorkHours);
         setPhase(fetchedPhases);
-      } catch (error) {
-        const errorMessage = await (error as any)?.response?.json();
+      } catch (error: any) {
+        const errorMessage = await error?.response?.json();
         setError(
           `${strings.sprintRequestError.fetchWorkHoursAndTasksError}: ${errorMessage?.message || error}`
         );

--- a/src/components/sprint-view-table/tasks-table.tsx
+++ b/src/components/sprint-view-table/tasks-table.tsx
@@ -1,13 +1,6 @@
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import {
-	Box,
-	Card,
-	CircularProgress,
-	IconButton,
-	Typography,
-	useTheme,
-} from "@mui/material";
+import { Box, Card, CircularProgress, IconButton, Typography, useTheme } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useState } from "react";
@@ -15,11 +8,11 @@ import { userProfileAtom } from "src/atoms/auth";
 import { errorAtom } from "src/atoms/error";
 import { usersAtom } from "src/atoms/user";
 import type {
-	Phase,
-	ResourceAllocations,
-	ResourceAllocationsProject,
-	User,
-	WorkHours,
+  Phase,
+  ResourceAllocations,
+  ResourceAllocationsProject,
+  User,
+  WorkHours
 } from "src/generated/homeLambdasClient";
 import { useLambdasApi } from "src/hooks/use-api";
 import useUserRole from "src/hooks/use-user-role";
@@ -32,8 +25,8 @@ import sprintViewTasksColumns from "./sprint-tasks-columns";
  * Interface for TaskTable component
  */
 interface Props {
-	filter?: string;
-	project: ResourceAllocationsProject;
+  filter?: string;
+  project: ResourceAllocationsProject;
 }
 
 /**
@@ -42,162 +35,149 @@ interface Props {
  * @param props component properties
  */
 const TaskTable = ({ filter, project }: Props) => {
-	const theme = useTheme();
-	const users = useAtomValue(usersAtom);
-	const { adminMode } = useUserRole();
-	const userProfile = useAtomValue(userProfileAtom);
-	const loggedInUser = users.find(
-		(users: User) => users.id === userProfile?.id,
-	);
-	const { phaseApi, workHoursApi, resourceAllocationsApi } = useLambdasApi();
-	const [phase, setPhase] = useState<Phase[]>([]);
-	const [workHours, setWorkHours] = useState<WorkHours[]>([]);
-	const [resourceAllocations, setResourceAllocations] = useState<
-		ResourceAllocations[]
-	>([]);
-	const [open, setOpen] = useState(false);
-	const [loading, setLoading] = useState(false);
-	const columns = sprintViewTasksColumns();
-	const setError = useSetAtom(errorAtom);
-	const severaUserId = loggedInUser ? getSeveraUserId(loggedInUser) : "";
-	const rows: PhaseRow[] = phase
-		.map((phase) =>
-			mapPhasesToRows(
-				phase,
-				workHours,
-				severaUserId,
-				resourceAllocations,
-				adminMode,
-			),
-		)
-		.filter((row): row is PhaseRow => row !== null);
+  const theme = useTheme();
+  const users = useAtomValue(usersAtom);
+  const { adminMode } = useUserRole();
+  const userProfile = useAtomValue(userProfileAtom);
+  const loggedInUser = users.find((users: User) => users.id === userProfile?.id);
+  const { phaseApi, workHoursApi, resourceAllocationsApi } = useLambdasApi();
+  const [phase, setPhase] = useState<Phase[]>([]);
+  const [workHours, setWorkHours] = useState<WorkHours[]>([]);
+  const [resourceAllocations, setResourceAllocations] = useState<ResourceAllocations[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const columns = sprintViewTasksColumns();
+  const setError = useSetAtom(errorAtom);
+  const severaUserId = loggedInUser ? getSeveraUserId(loggedInUser) : "";
+  const rows: PhaseRow[] = phase
+    .map((phase) => mapPhasesToRows(phase, workHours, severaUserId, resourceAllocations, adminMode))
+    .filter((row): row is PhaseRow => row !== null);
 
-	/**
-	 * Get Phases and WorkHours for tasks
-	 */
-	const getPhasesAndWorkHours = useCallback(async () => {
-		if (!loggedInUser) return;
-		setLoading(true);
-		if (!phase?.length) {
-			try {
-				const severaProjectId = project?.severaProjectId || "";
-				const [fetchedResourceAllocations] = await Promise.all([
-					resourceAllocationsApi.getAllResourceAllocations({ severaUserId }),
-				]);
-				const [fetchedPhases, fetchedWorkHours] = await Promise.all([
-					phaseApi.getPhasesBySeveraProjectId({
-						severaProjectId,
-					}),
-					workHoursApi.getAllWorkHours({
-						severaProjectId,
-					}),
-				]);
-				setResourceAllocations(fetchedResourceAllocations);
-				setWorkHours(fetchedWorkHours);
-				setPhase(fetchedPhases);
-			} catch (error) {
-				setError(
-					`${strings.sprintRequestError.fetchWorkHoursAndTasksError} ${error}`,
-				);
-			}
-		}
-		setLoading(false);
-	}, [
-		loggedInUser,
-		phase,
-		project,
-		severaUserId,
-		phaseApi,
-		workHoursApi,
-		resourceAllocationsApi,
-		setError,
-	]);
+  /**
+   * Get Phases and WorkHours for tasks
+   */
+  const getPhasesAndWorkHours = useCallback(async () => {
+    if (!loggedInUser) return;
+    setLoading(true);
+    if (!phase?.length) {
+      try {
+        const severaProjectId = project?.severaProjectId || "";
+        const [fetchedResourceAllocations] = await Promise.all([
+          resourceAllocationsApi.getAllResourceAllocations({ severaUserId })
+        ]);
+        const [fetchedPhases, fetchedWorkHours] = await Promise.all([
+          phaseApi.getPhasesBySeveraProjectId({
+            severaProjectId
+          }),
+          workHoursApi.getAllWorkHours({
+            severaProjectId
+          })
+        ]);
+        setResourceAllocations(fetchedResourceAllocations);
+        setWorkHours(fetchedWorkHours);
+        setPhase(fetchedPhases);
+      } catch (error) {
+        const errorMessage = await (error as any)?.response?.json();
+        setError(
+          `${strings.sprintRequestError.fetchWorkHoursAndTasksError}: ${errorMessage?.message || error}`
+        );
+      }
+    }
+    setLoading(false);
+  }, [
+    loggedInUser,
+    phase,
+    project,
+    severaUserId,
+    phaseApi,
+    workHoursApi,
+    resourceAllocationsApi,
+    setError
+  ]);
 
-	useEffect(() => {
-		if (project && open) {
-			getPhasesAndWorkHours();
-		}
-	}, [project, open, getPhasesAndWorkHours]);
+  useEffect(() => {
+    if (project && open) {
+      getPhasesAndWorkHours();
+    }
+  }, [project, open, getPhasesAndWorkHours]);
 
-	return (
-		<Card
-			key={0}
-			sx={{
-				backgroundColor: theme.palette.background.paper,
-				margin: 0,
-				paddingTop: "5px",
-				paddingBottom: "5px",
-				width: "100%",
-				height: "100",
-				marginBottom: "16px",
-				"& .high_priority": {
-					color: theme.palette.error.main,
-				},
-				"& .low_priority": {
-					color: theme.palette.success.main,
-				},
-			}}
-		>
-			<Box
-				onClick={() => setOpen(!open)}
-				sx={{
-					display: "flex",
-					alignItems: "center",
-					padding: "2px",
-					width: "100%",
-					cursor: "pointer",
-				}}
-			>
-				<IconButton>
-					{open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-				</IconButton>
-				<Typography>{project.name}</Typography>
-			</Box>
-			{open &&
-				(loading ? (
-					<Box sx={{ textAlign: "center" }}>
-						<CircularProgress
-							sx={{
-								scale: "100%",
-								mt: "3%",
-								mb: "3%",
-							}}
-						/>
-					</Box>
-				) : (
-					<DataGrid
-						sx={{
-							backgroundColor: theme.palette.background.default,
-							borderTop: 0,
-							borderLeft: 0,
-							borderRight: 0,
-							borderBottom: 0,
-							"& .header-color": {
-								backgroundColor: theme.palette.background.paper,
-							},
+  return (
+    <Card
+      key={0}
+      sx={{
+        backgroundColor: theme.palette.background.paper,
+        margin: 0,
+        paddingTop: "5px",
+        paddingBottom: "5px",
+        width: "100%",
+        height: "100",
+        marginBottom: "16px",
+        "& .high_priority": {
+          color: theme.palette.error.main
+        },
+        "& .low_priority": {
+          color: theme.palette.success.main
+        }
+      }}
+    >
+      <Box
+        onClick={() => setOpen(!open)}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          padding: "2px",
+          width: "100%",
+          cursor: "pointer"
+        }}
+      >
+        <IconButton>{open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}</IconButton>
+        <Typography>{project.name}</Typography>
+      </Box>
+      {open &&
+        (loading ? (
+          <Box sx={{ textAlign: "center" }}>
+            <CircularProgress
+              sx={{
+                scale: "100%",
+                mt: "3%",
+                mb: "3%"
+              }}
+            />
+          </Box>
+        ) : (
+          <DataGrid
+            sx={{
+              backgroundColor: theme.palette.background.default,
+              borderTop: 0,
+              borderLeft: 0,
+              borderRight: 0,
+              borderBottom: 0,
+              "& .header-color": {
+                backgroundColor: theme.palette.background.paper
+              },
 
-							"& .MuiDataGrid-row:hover": {
-								backgroundColor: theme.palette.action.hover,
-							},
-						}}
-						localeText={{ noResultsOverlayLabel: strings.sprint.notFound }}
-						disableColumnFilter
-						hideFooter={true}
-						filterModel={{
-							items: [
-								{
-									field: "status",
-									operator: "contains",
-									value: filter,
-								},
-							],
-						}}
-						rows={rows}
-						columns={columns}
-					/>
-				))}
-		</Card>
-	);
+              "& .MuiDataGrid-row:hover": {
+                backgroundColor: theme.palette.action.hover
+              }
+            }}
+            localeText={{ noResultsOverlayLabel: strings.sprint.notFound }}
+            disableColumnFilter
+            hideFooter={true}
+            filterModel={{
+              items: [
+                {
+                  field: "status",
+                  operator: "contains",
+                  value: filter
+                }
+              ]
+            }}
+            rows={rows}
+            columns={columns}
+          />
+        ))}
+    </Card>
+  );
 };
 
 export default TaskTable;

--- a/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
+++ b/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
@@ -78,8 +78,9 @@ const ToolbarFormFields = ({
         });
         setWorkWeek(contractedWeekToBoolean(data.contractedWeek));
         setError(null);
-      } catch {
-        setError(strings.error.fetchWorkWeekFailed);
+      } catch (error:any) {
+        const errorMessage = (error as any)?.response?.json();
+        setError(`${strings.error.fetchWorkWeekFailed}: ${errorMessage?.message || error}`);
         setWorkWeek([true, true, true, true, true, false, false]);
       }
     };

--- a/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
+++ b/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
@@ -78,8 +78,8 @@ const ToolbarFormFields = ({
         });
         setWorkWeek(contractedWeekToBoolean(data.contractedWeek));
         setError(null);
-      } catch (error:any) {
-        const errorMessage = (error as any)?.response?.json();
+      } catch (error: any) {
+        const errorMessage = await error?.response?.json();
         setError(`${strings.error.fetchWorkWeekFailed}: ${errorMessage?.message || error}`);
         setWorkWeek([true, true, true, true, true, false, false]);
       }

--- a/src/components/vacation-requests-table/vacation-requests-table.tsx
+++ b/src/components/vacation-requests-table/vacation-requests-table.tsx
@@ -207,8 +207,11 @@ const VacationRequestsTable = ({
   useMemo(() => {
     try {
       setRows(createDataGridRows(vacationRequests));
-    } catch (error) {
-      console.error("Error creating data grid rows:", error);
+    } catch (error: any) {
+      const errorMessage = (error as any)?.response?.json();
+      console.error(
+        ` ${strings.vacationRequestError.failedToLoad}: ${errorMessage?.message || error}`
+      );
       setRows([]);
     }
   }, [vacationRequests, formOpen]);

--- a/src/components/vacation-requests-table/vacation-requests-table.tsx
+++ b/src/components/vacation-requests-table/vacation-requests-table.tsx
@@ -208,7 +208,7 @@ const VacationRequestsTable = ({
     try {
       setRows(createDataGridRows(vacationRequests));
     } catch (error: any) {
-      const errorMessage = (error as any)?.response?.json();
+      const errorMessage = error?.response?.json();
       console.error(
         ` ${strings.vacationRequestError.failedToLoad}: ${errorMessage?.message || error}`
       );

--- a/src/components/work-hours/workDays-chart.tsx
+++ b/src/components/work-hours/workDays-chart.tsx
@@ -116,8 +116,9 @@ const WorkDaysChart = ({ selectedEmployee }: { selectedEmployee?: User }) => {
         holidayName: w.holidayName ?? null
       }));
       setWorkdays(mapped);
-    } catch (err) {
-      setError(`${strings.error.fetchWorkDaysFailed}, ${err}`);
+    } catch (error: any) {
+      const errorMessage = await error.response.json();
+      setError(`${strings.error.fetchFailedFlextime}: ${errorMessage.message}`);
     }
   };
 

--- a/src/hooks/use-create-software.ts
+++ b/src/hooks/use-create-software.ts
@@ -24,8 +24,9 @@ const useCreateSoftware = (
         softwareRegistry: newSoftware
       });
       setApplications((prev) => [createdSoftware, ...prev]);
-    } catch (error) {
-      setError(`${strings.softwareRegistry.errorCreatingSoftware} ${error}`);
+    } catch (error:any) {
+      const errorMessage = (error as any)?.response?.json();
+      setError(`${strings.softwareRegistry.errorCreatingSoftware} ${errorMessage?.message || error}`);
     } finally {
       setLoading(false);
     }

--- a/src/hooks/use-create-software.ts
+++ b/src/hooks/use-create-software.ts
@@ -24,9 +24,11 @@ const useCreateSoftware = (
         softwareRegistry: newSoftware
       });
       setApplications((prev) => [createdSoftware, ...prev]);
-    } catch (error:any) {
-      const errorMessage = (error as any)?.response?.json();
-      setError(`${strings.softwareRegistry.errorCreatingSoftware} ${errorMessage?.message || error}`);
+    } catch (error: any) {
+      const errorMessage = await error?.response?.json();
+      setError(
+        `${strings.softwareRegistry.errorCreatingSoftware} ${errorMessage?.message || error}`
+      );
     } finally {
       setLoading(false);
     }

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -46,7 +46,9 @@
     "noArticleId": "Article ID is missing",
     "fetchWorkDaysFailed": "Fetching work days data has failed",
     "fetchWorkWeekFailed": "Error while fetching work week data, five day week will be used.",
-    "fetchFailedSevera": "Failed to update Severa opt-in."
+    "fetchFailedSevera": "Failed to update Severa opt-in.",
+    "fetchFailedQuestionnaires": "Failed to fetch questionnaires.",
+    "fetchFailedSoftwareData": "Failed to fetch software registry data."
   },
   "localization": {
     "en": "EN",
@@ -262,7 +264,8 @@
     "noVacationRequestsFound": "No vacation requests found",
     "nameNotFound": "Name not found",
     "noVacationRequestsStatusFound": "Statuses not found",
-    "invalidNumberOfDays": "You cannot set a vacation request to 0 days",
+    "invalidNumberOfDaysUser": "You cannot request a 0 days vacation",
+    "invalidNumberOfDaysAdmin": "You cannot set a vacation request to 0 days",
     "tooManyDaysRequestedUser": "You cannot request {requestedDays} days. You only have {unspentDays} unspent vacation days.",
     "tooManyDaysRequestedAdmin": "Not enough vacation days. Requested: {requestedDays} days, Available: {unspentDays} days.",
     "noVacationDaysAvailable": "You don't have any vacation days available for the current vacation year. Please contact your administrator.",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -262,6 +262,7 @@
     "noVacationRequestsFound": "No vacation requests found",
     "nameNotFound": "Name not found",
     "noVacationRequestsStatusFound": "Statuses not found",
+    "invalidNumberOfDays": "You cannot set a vacation request to 0 days",
     "tooManyDaysRequestedUser": "You cannot request {requestedDays} days. You only have {unspentDays} unspent vacation days.",
     "tooManyDaysRequestedAdmin": "Not enough vacation days. Requested: {requestedDays} days, Available: {unspentDays} days.",
     "noVacationDaysAvailable": "You don't have any vacation days available for the current vacation year. Please contact your administrator.",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -48,7 +48,15 @@
     "fetchWorkWeekFailed": "Error while fetching work week data, five day week will be used.",
     "fetchFailedSevera": "Failed to update Severa opt-in.",
     "fetchFailedQuestionnaires": "Failed to fetch questionnaires.",
-    "fetchFailedSoftwareData": "Failed to fetch software registry data."
+    "fetchFailedWikiArticles": "Failed to fetch wiki articles.",
+    "fetchFailedSoftwareData": "Failed to fetch software registry data.",
+    "loadUserProfileFailed": "Failed to load user profile.",
+    "softwareFetchFailed": "Error fetching software data.",
+    "softwareStatusUpdateFailed": "Error updating software status.",
+    "softwareSaveFailed": "Error saving the software.",
+    "softwareDeleteFailed": "Error deleting the software.",
+    "softwareRegistryFetchFailed": "Error while fetching software registry data",
+    "softwareRegistryUpdateFailed": "Error while updating software registry"
   },
   "localization": {
     "en": "EN",
@@ -162,7 +170,12 @@
     "loading": "Loading...",
     "errorUnknownUser": "Unknown user",
     "errorCreatingSoftware": "Error creating software:",
-    "errorFetchingSoftwareToList": "Error fetching software to list:"
+    "errorFetchingSoftwareToList": "Error fetching software to list:",
+    "softwareDetailsFetchFailed": "Error fetching software details",
+    "softwareDetailsRemoveUserFailed": "Error removing user from software",
+    "softwareDetailsAddUserFailed": "Error adding user to software",
+    "softwareDetailsUpdateFailed": "Error updating software",
+    "recommendationsFetchUserFailed": "Error fetching user data"
   },
   "softwareStatus": {
     "all": "All",
@@ -259,6 +272,7 @@
     "createStatusError": "Creating vacation request status has failed ",
     "deleteRequestError": "Deleting vacation requests has failed",
     "deleteStatusError": "Deleting vacation request statuses has failed",
+    "dataGridRowsCreationError": "Error creating vacation request rows",
     "updateRequestError": "Updating vacation request has failed",
     "updateStatusError": "Updating vacation request status has failed",
     "noVacationRequestsFound": "No vacation requests found",

--- a/src/localization/fi.json
+++ b/src/localization/fi.json
@@ -260,6 +260,7 @@
     "updateRequestError": "Lomahakemuksen päivittäminen epäonnistui",
     "updateStatusError": "Lomahakemuksen tilan päivittäminen epäonnistui",
     "noVacationRequestsFound": "Lomahakemuksia ei löydetty",
+    "invalidNumberOfDays": "Et voi asettaa lomahakemusta 0 päivään",
     "nameNotFound": "Nimeä ei löydetty",
     "noVacationRequestsStatusFound": "Tiloja ei löytynyt",
     "tooManyDaysRequestedUser": "Et voi pyytää {requestedDays} päivää. Sinulla on käytettävissä vain {unspentDays} lomapäivää.",

--- a/src/localization/fi.json
+++ b/src/localization/fi.json
@@ -48,7 +48,15 @@
     "fetchFailedSevera": "Severa-opt-in päivitys epäonnistui.",
     "fetchWorkWeekFailed": "Virhe työviikon tietoja haettaessa, käytetään oletuksena viiden päivän viikkoa",
     "fetchFailedQuestionnaires": "Kyselylomakkeiden lataaminen epäonnistui",
-    "fetchFailedSoftwareData": "Ohjelmistorekisterin tietojen haku epäonnistui"
+    "fetchFailedWikiArticles": "Wiki-artikkelien lataaminen epäonnistui",
+    "fetchFailedSoftwareData": "Ohjelmistorekisterin tietojen haku epäonnistui",
+    "loadUserProfileFailed": "Käyttäjäprofiilin lataaminen epäonnistui",
+    "softwareFetchFailed": "Ohjelmistojen haku epäonnistui.",
+    "softwareStatusUpdateFailed": "Ohjelmiston tilan päivittäminen epäonnistui.",
+    "softwareSaveFailed": "Ohjelmiston tallentaminen epäonnistui.",
+    "softwareDeleteFailed": "Ohjelmiston poistaminen epäonnistui.",
+    "softwareRegistryFetchFailed": "Ohjelmistorekisterin tietojen hakeminen epäonnistui",
+    "softwareRegistryUpdateFailed": "Ohjelmistorekisterin päivittäminen epäonnistui"
   },
   "localization": {
     "en": "EN",
@@ -162,7 +170,12 @@
     "loading": "Ladataan...",
     "errorUnknownUser": "Tuntematon käyttäjä",
     "errorCreatingSoftware": "Virhe ohjelmiston luomisessa",
-    "errorFetchingSoftwareToList": "Virhe ohjelmistojen hakemisessa listattavaksi"
+    "errorFetchingSoftwareToList": "Virhe ohjelmistojen hakemisessa listattavaksi",
+    "softwareDetailsFetchFailed": "Virhe sovelluksen yksityiskohtien hakemisessa",
+    "softwareDetailsRemoveUserFailed": "Virhe käyttäjän poistamisessa sovelluksesta",
+    "softwareDetailsAddUserFailed": "Virhe käyttäjän lisäämisessä sovellukseen",
+    "softwareDetailsUpdateFailed": "Virhe sovelluksen päivittämisessä",
+    "recommendationsFetchUserFailed": "Virhe käyttäjätietojen hakemisessa"
   },
   "softwareStatus": {
     "all": "Kaikki",
@@ -259,6 +272,7 @@
     "createStatusError": "Lomahakemuksen tilan luominen epäonnistui",
     "deleteRequestError": "Lomahakemuksen poistaminen epäonnistui",
     "deleteStatusError": "Lomahakemuksen tilan poistaminen epäonnistui",
+    "dataGridRowsCreationError": "Virhe lomahakemuksen rivien luomisessa",
     "updateRequestError": "Lomahakemuksen päivittäminen epäonnistui",
     "updateStatusError": "Lomahakemuksen tilan päivittäminen epäonnistui",
     "noVacationRequestsFound": "Lomahakemuksia ei löydetty",

--- a/src/localization/fi.json
+++ b/src/localization/fi.json
@@ -46,7 +46,9 @@
     "noArticleId": "Artikkelin ID puuttuu",
     "fetchWorkDaysFailed": "Työpäivätietojen haku epäonnistui",
     "fetchFailedSevera": "Severa-opt-in päivitys epäonnistui.",
-    "fetchWorkWeekFailed": "Virhe työviikon tietoja haettaessa, käytetään oletuksena viiden päivän viikkoa"
+    "fetchWorkWeekFailed": "Virhe työviikon tietoja haettaessa, käytetään oletuksena viiden päivän viikkoa",
+    "fetchFailedQuestionnaires": "Kyselylomakkeiden lataaminen epäonnistui",
+    "fetchFailedSoftwareData": "Ohjelmistorekisterin tietojen haku epäonnistui"
   },
   "localization": {
     "en": "EN",
@@ -260,7 +262,8 @@
     "updateRequestError": "Lomahakemuksen päivittäminen epäonnistui",
     "updateStatusError": "Lomahakemuksen tilan päivittäminen epäonnistui",
     "noVacationRequestsFound": "Lomahakemuksia ei löydetty",
-    "invalidNumberOfDays": "Et voi asettaa lomahakemusta 0 päivään",
+    "invalidNumberOfDaysUser": "Et voi pyytää 0 päivän lomaa",
+    "invalidNumberOfDaysAdmin": "Et voi asettaa lomahakemusta 0 päiväksi",
     "nameNotFound": "Nimeä ei löydetty",
     "noVacationRequestsStatusFound": "Tiloja ei löytynyt",
     "tooManyDaysRequestedUser": "Et voi pyytää {requestedDays} päivää. Sinulla on käytettävissä vain {unspentDays} lomapäivää.",

--- a/src/localization/strings.ts
+++ b/src/localization/strings.ts
@@ -63,6 +63,8 @@ export interface Localized extends LocalizedStringsMethods {
     fetchWorkDaysFailed: string;
     fetchWorkWeekFailed: string;
     fetchFailedSevera: string;
+    fetchFailedQuestionnaires: string;
+    fetchFailedSoftwareData: string;
   };
   /**
    * Translations related to localization
@@ -297,7 +299,8 @@ export interface Localized extends LocalizedStringsMethods {
     noVacationRequestsStatusFound: string;
     tooManyDaysRequestedUser: string;
     tooManyDaysRequestedAdmin: string;
-    invalidNumberOfDays: string;
+    invalidNumberOfDaysUser: string;
+    invalidNumberOfDaysAdmin: string;
     noVacationDaysAvailable: string;
     failedToLoad: string;
   };

--- a/src/localization/strings.ts
+++ b/src/localization/strings.ts
@@ -64,7 +64,15 @@ export interface Localized extends LocalizedStringsMethods {
     fetchWorkWeekFailed: string;
     fetchFailedSevera: string;
     fetchFailedQuestionnaires: string;
+    fetchFailedWikiArticles: string;
     fetchFailedSoftwareData: string;
+    loadUserProfileFailed: string;
+    softwareFetchFailed: string;
+    softwareStatusUpdateFailed: string;
+    softwareSaveFailed: string;
+    softwareDeleteFailed: string;
+    softwareRegistryFetchFailed: string;
+    softwareRegistryUpdateFailed: string;
   };
   /**
    * Translations related to localization
@@ -192,6 +200,11 @@ export interface Localized extends LocalizedStringsMethods {
     errorUnknownUser: string;
     errorCreatingSoftware: string;
     errorFetchingSoftwareToList: string;
+    softwareDetailsFetchFailed: string;
+    softwareDetailsRemoveUserFailed: string;
+    softwareDetailsAddUserFailed: string;
+    softwareDetailsUpdateFailed: string;
+    recommendationsFetchUserFailed: string;
   };
 
   /**
@@ -292,6 +305,7 @@ export interface Localized extends LocalizedStringsMethods {
     createStatusError: string;
     deleteRequestError: string;
     deleteStatusError: string;
+    dataGridRowsCreationError: string;
     updateRequestError: string;
     updateStatusError: string;
     noVacationRequestsFound: string;

--- a/src/localization/strings.ts
+++ b/src/localization/strings.ts
@@ -297,6 +297,7 @@ export interface Localized extends LocalizedStringsMethods {
     noVacationRequestsStatusFound: string;
     tooManyDaysRequestedUser: string;
     tooManyDaysRequestedAdmin: string;
+    invalidNumberOfDays: string;
     noVacationDaysAvailable: string;
     failedToLoad: string;
   };

--- a/src/utils/vacations-utils.ts
+++ b/src/utils/vacations-utils.ts
@@ -124,6 +124,7 @@ export const validateVacationRequestDays = (
     const errorMessage = isUserAdmin
       ? strings.vacationRequestError.invalidNumberOfDaysAdmin
       : strings.vacationRequestError.invalidNumberOfDaysUser;
+
     return {
       valid: false,
       errorMessage: errorMessage

--- a/src/utils/vacations-utils.ts
+++ b/src/utils/vacations-utils.ts
@@ -120,6 +120,12 @@ export const validateVacationRequestDays = (
       errorMessage: errorString
     };
   }
+  if (requestedDays <= 0) {
+    return {
+      valid: false,
+      errorMessage: strings.vacationRequestError.invalidNumberOfDays
+    };
+  }
   return { valid: true };
 };
 

--- a/src/utils/vacations-utils.ts
+++ b/src/utils/vacations-utils.ts
@@ -121,9 +121,12 @@ export const validateVacationRequestDays = (
     };
   }
   if (requestedDays <= 0) {
+    const errorMessage = isUserAdmin
+      ? strings.vacationRequestError.invalidNumberOfDaysAdmin
+      : strings.vacationRequestError.invalidNumberOfDaysUser;
     return {
       valid: false,
-      errorMessage: strings.vacationRequestError.invalidNumberOfDays
+      errorMessage: errorMessage
     };
   }
   return { valid: true };


### PR DESCRIPTION
Now, when requesting a 0-day vacation (Saturday to Sunday), it shows a more explanatory message:
<img width="1315" height="913" alt="image" src="https://github.com/user-attachments/assets/9e9abb76-d79b-4bdc-aad2-541cdc7e0f39" />

The same happens when the admin tries to set a vacation request to 0:
<img width="1424" height="1167" alt="image" src="https://github.com/user-attachments/assets/70b37c08-be57-41c6-89e7-f10d978d1e29" />
These verifications are currently implemented on the frontend, which is good, but they should also be enforced on the backend.

Additionally, the error message is now added to some catch blocks to show the backend error to the user instead of a generic one (see before and after).

<img width="772" height="420" alt="image" src="https://github.com/user-attachments/assets/88b09419-80df-4710-b56c-846e2fa3be85" />
<img width="1536" height="1055" alt="image" src="https://github.com/user-attachments/assets/5e9395a7-7efe-4f2e-943f-b750076ea628" />

This particular error shouldn’t be showing and requires further investigation, but it’s useful to see the difference.