### PR TITLE
Path article text

### DIFF
--- a/src/components/wiki-documentation/create-article-form.tsx
+++ b/src/components/wiki-documentation/create-article-form.tsx
@@ -214,7 +214,9 @@ const CreateOrEditArticleForm = ({
   const handleTitleChange = (event: any) => {
     const newInput = event.target.value;
     setTitle(newInput);
-    setPath(`${newInput.replace(/\s+/g, "_").replace(/[^a-zA-Z0-9\-_]/g, "")}`);
+    if (action === "create") {
+      setPath(`${newInput.replace(/\s+/g, "_").replace(/[^a-zA-Z0-9\-_]/g, "")}`);
+    }
   };
 
   const handlePathChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -458,7 +458,7 @@
     "uploadImage": "Upload image",
     "imagePreview": "Preview",
     "labelTitle": "Title",
-    "labelPath": "Path",
+    "labelPath": "Custom path",
     "labelTags": "Tags",
     "labelImage": "Image URL",
     "labelDescription": "Description",

--- a/src/localization/fi.json
+++ b/src/localization/fi.json
@@ -458,7 +458,7 @@
     "uploadImage": "Lataa kuva",
     "imagePreview": "Esikatselu",
     "labelTitle": "Otsikko",
-    "labelPath": "Polku",
+    "labelPath": "Mukautettu polku",
     "labelTags": "Tunnisteet",
     "labelImage": "Kuvan URL-osoite",
     "labelDescription": "Kuvaus",


### PR DESCRIPTION
Changed text from creating or editing the path for an article. 
Also updated the article path behavior: when creating a new article, the path is generated from the title. When editing, the path stays unchanged unless manually modified. This prevents the URL from changing unintentionally when updating the title, avoiding broken links for existing articles.