### PR TITLE
Feature 442 duplicate vacation requests and admin dates change

### DIFF
--- a/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
+++ b/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
@@ -93,7 +93,7 @@ const ToolbarFormFields = ({
     originalStartDateRef.current = null;
   }, [toolbarFormMode]);
 
-  // Update vacation request whenever date range changesei
+  // Update vacation request whenever date range changes
   useEffect(() => {
     if (!dateRange.start || !dateRange.end) return;
     // Store original end date on first load
@@ -111,22 +111,13 @@ const ToolbarFormFields = ({
     const isModified =
       !dateRange.start.hasSame(originalStart, "day") || !dateRange.end.hasSame(originalEnd, "day");
 
-    if (!adminMode) {
+    if (isModified) {
       setVacationRequestData({
         ...vacationRequestData,
         startDate: dateRange.start.toJSDate(),
         endDate: dateRange.end.toJSDate(),
         days
       });
-    } else {
-      if (isModified) {
-        setVacationRequestData({
-          ...vacationRequestData,
-          startDate: dateRange.start.toJSDate(),
-          endDate: dateRange.end.toJSDate(),
-          days
-        });
-      }
     }
   }, [dateRange, workWeek, adminMode]);
 

--- a/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
+++ b/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
@@ -18,11 +18,7 @@ import useUserRole from "src/hooks/use-user-role";
 import strings from "src/localization/strings";
 import { type DateRange, ToolbarFormModes } from "src/types";
 import { hasAllPropsDefined } from "src/utils/check-utils";
-import {
-  calculateEndDateFromDays,
-  calculateTotalVacationDays,
-  contractedWeekToBoolean
-} from "src/utils/time-utils";
+import { calculateTotalVacationDays, contractedWeekToBoolean } from "src/utils/time-utils";
 import DateRangePicker from "../../../generics/date-range-picker";
 
 /**
@@ -141,17 +137,9 @@ const ToolbarFormFields = ({
    */
   const handleDaysChange = (value: string) => {
     const daysValue = Number.parseInt(value, 10) || 0;
-    if (!dateRange.start) return;
-
-    const newEndDate = calculateEndDateFromDays(dateRange.start, daysValue, workWeek);
-    setDateRange({
-      start: dateRange.start,
-      end: newEndDate
-    });
     setVacationRequestData({
       ...vacationRequestData,
-      days: daysValue,
-      endDate: newEndDate.toJSDate()
+      days: daysValue
     });
   };
 
@@ -196,7 +184,7 @@ const ToolbarFormFields = ({
           />
         </>
       )}
-      {adminMode ? (
+      {adminMode && (
         <>
           <FormLabel>{strings.vacationRequest.days}</FormLabel>
           <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1, mb: 1 }}>
@@ -214,16 +202,13 @@ const ToolbarFormFields = ({
             </Button>
           </Box>
         </>
-      ) : (
-        <>
-          <FormLabel sx={{ marginBottom: "5px" }}>{strings.vacationRequest.days}</FormLabel>
-          <DateRangePicker
-            dateTimeTomorrow={dateTimeTomorrow}
-            dateRange={dateRange}
-            setDateRange={setDateRange}
-          />
-        </>
       )}
+      <FormLabel sx={{ marginBottom: "5px" }}>{strings.vacationRequest.days}</FormLabel>
+      <DateRangePicker
+        dateTimeTomorrow={dateTimeTomorrow}
+        dateRange={dateRange}
+        setDateRange={setDateRange}
+      />
       {toolbarFormMode === ToolbarFormModes.CREATE && (
         <Grid container spacing={2}>
           <Grid size={6}>

--- a/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
+++ b/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form-fields.tsx
@@ -59,6 +59,7 @@ const ToolbarFormFields = ({
   const { workHoursApi } = useLambdasApi();
   const [error, setError] = useState<string | null>(null);
   const originalEndDateRef = useRef<DateTime | null>(null);
+  const originalStartDateRef = useRef<DateTime | null>(null);
 
   /**
    * Fetch contracted work week, defaults to 5 day if it fails
@@ -89,17 +90,26 @@ const ToolbarFormFields = ({
    */
   useEffect(() => {
     originalEndDateRef.current = null;
+    originalStartDateRef.current = null;
   }, [toolbarFormMode]);
 
-  // Update vacation request whenever date range changes
+  // Update vacation request whenever date range changesei
   useEffect(() => {
     if (!dateRange.start || !dateRange.end) return;
     // Store original end date on first load
-    if (originalEndDateRef.current === null) {
+    if (!originalEndDateRef.current && !originalStartDateRef.current) {
       originalEndDateRef.current = dateRange.end;
+      originalStartDateRef.current = dateRange.start;
     }
 
+    const originalStart = originalStartDateRef.current;
+    const originalEnd = originalEndDateRef.current;
+
+    if (!originalStart || !originalEnd) return;
+
     const days = calculateTotalVacationDays(dateRange.start, dateRange.end, workWeek);
+    const isModified =
+      !dateRange.start.hasSame(originalStart, "day") || !dateRange.end.hasSame(originalEnd, "day");
 
     if (!adminMode) {
       setVacationRequestData({
@@ -109,11 +119,14 @@ const ToolbarFormFields = ({
         days
       });
     } else {
-      setVacationRequestData({
-        ...vacationRequestData,
-        startDate: dateRange.start.toJSDate(),
-        endDate: dateRange.end.toJSDate()
-      });
+      if (isModified) {
+        setVacationRequestData({
+          ...vacationRequestData,
+          startDate: dateRange.start.toJSDate(),
+          endDate: dateRange.end.toJSDate(),
+          days
+        });
+      }
     }
   }, [dateRange, workWeek, adminMode]);
 

--- a/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form.tsx
+++ b/src/components/vacation-requests-table/vacation-requests-table-toolbar/toolbar-form/toolbar-form.tsx
@@ -149,8 +149,8 @@ const ToolbarForm = ({
    * Handle create vacation request
    */
   const handleCreate = async () => {
-    await createVacationRequest(vacationRequestData);
     setFormOpen(false);
+    await createVacationRequest(vacationRequestData);
   };
 
   /**
@@ -177,8 +177,8 @@ const ToolbarForm = ({
    *  Handle draft vacation request creation
    */
   const handleDraft = async () => {
-    await createDraftVacationRequest(vacationRequestData);
     setFormOpen(false);
+    await createDraftVacationRequest(vacationRequestData);
   };
 
   return (

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -104,46 +104,6 @@ export const calculateTotalVacationDays = (
 };
 
 /**
- * NOTE: This function is no longer in use, should it be removed, or is it
- * needed later on?
- *
- * Calculates new endDate for vacation request after admin has updated the days count
- *
- * @param startDate - The starting date as a Luxon `DateTime`.
- * @param totalDays - The total number of vacation days to count.
- * @param workWeek - An array of 7 booleans (index 0 = Monday, index 6 = Sunday)
- *                   indicating which days are considered working days.
- * @returns A Luxon `DateTime` representing the calculated end date.
- */
-export const calculateEndDateFromDays = (
-  startDate: DateTime,
-  totalDays: number,
-  workWeek: boolean[]
-) => {
-  const workDaysInWeek = workWeek.filter(Boolean).length;
-  let daysAdded = 0;
-  let currentDate = startDate;
-  const [startWeek, endWeek] = getIndexDaysWorking(workWeek);
-  if (!startWeek || !endWeek) return startDate;
-  while (daysAdded < totalDays) {
-    const weekdayIndex = currentDate.weekday;
-    const isWorkingDay = workWeek[weekdayIndex - 1];
-    const reachedTotal = daysAdded >= totalDays;
-    const endOfWorkWeek = daysAdded % workDaysInWeek === 0;
-    if (isWorkingDay) {
-      daysAdded++;
-    }
-    if (!reachedTotal && endOfWorkWeek && isWorkingDay) {
-      daysAdded++;
-    }
-    if (!reachedTotal) {
-      currentDate = currentDate.plus({ days: 1 });
-    }
-  }
-  return currentDate;
-};
-
-/**
  * Get indexes - start and end day of working week
  *
  * @param workingWeek list of booleans representing which days are working days

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -104,43 +104,6 @@ export const calculateTotalVacationDays = (
 };
 
 /**
- * Calculates new endDate for vacation request after admin has updated the days count
- *
- * @param startDate - The starting date as a Luxon `DateTime`.
- * @param totalDays - The total number of vacation days to count.
- * @param workWeek - An array of 7 booleans (index 0 = Monday, index 6 = Sunday)
- *                   indicating which days are considered working days.
- * @returns A Luxon `DateTime` representing the calculated end date.
- */
-export const calculateEndDateFromDays = (
-  startDate: DateTime,
-  totalDays: number,
-  workWeek: boolean[]
-) => {
-  const workDaysInWeek = workWeek.filter(Boolean).length;
-  let daysAdded = 0;
-  let currentDate = startDate;
-  const [startWeek, endWeek] = getIndexDaysWorking(workWeek);
-  if (!startWeek || !endWeek) return startDate;
-  while (daysAdded < totalDays) {
-    const weekdayIndex = currentDate.weekday;
-    const isWorkingDay = workWeek[weekdayIndex - 1];
-    const reachedTotal = daysAdded >= totalDays;
-    const endOfWorkWeek = daysAdded % workDaysInWeek === 0;
-    if (isWorkingDay) {
-      daysAdded++;
-    }
-    if (!reachedTotal && endOfWorkWeek && isWorkingDay) {
-      daysAdded++;
-    }
-    if (!reachedTotal) {
-      currentDate = currentDate.plus({ days: 1 });
-    }
-  }
-  return currentDate;
-};
-
-/**
  * Get indexes - start and end day of working week
  *
  * @param workingWeek list of booleans representing which days are working days

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -104,6 +104,46 @@ export const calculateTotalVacationDays = (
 };
 
 /**
+ * NOTE: This function is no longer in use, should it be removed, or is it
+ * needed later on?
+ *
+ * Calculates new endDate for vacation request after admin has updated the days count
+ *
+ * @param startDate - The starting date as a Luxon `DateTime`.
+ * @param totalDays - The total number of vacation days to count.
+ * @param workWeek - An array of 7 booleans (index 0 = Monday, index 6 = Sunday)
+ *                   indicating which days are considered working days.
+ * @returns A Luxon `DateTime` representing the calculated end date.
+ */
+export const calculateEndDateFromDays = (
+  startDate: DateTime,
+  totalDays: number,
+  workWeek: boolean[]
+) => {
+  const workDaysInWeek = workWeek.filter(Boolean).length;
+  let daysAdded = 0;
+  let currentDate = startDate;
+  const [startWeek, endWeek] = getIndexDaysWorking(workWeek);
+  if (!startWeek || !endWeek) return startDate;
+  while (daysAdded < totalDays) {
+    const weekdayIndex = currentDate.weekday;
+    const isWorkingDay = workWeek[weekdayIndex - 1];
+    const reachedTotal = daysAdded >= totalDays;
+    const endOfWorkWeek = daysAdded % workDaysInWeek === 0;
+    if (isWorkingDay) {
+      daysAdded++;
+    }
+    if (!reachedTotal && endOfWorkWeek && isWorkingDay) {
+      daysAdded++;
+    }
+    if (!reachedTotal) {
+      currentDate = currentDate.plus({ days: 1 });
+    }
+  }
+  return currentDate;
+};
+
+/**
  * Get indexes - start and end day of working week
  *
  * @param workingWeek list of booleans representing which days are working days


### PR DESCRIPTION
- Admin is now able to change the _days consumed_ of vacation without the dates changing
- Admin is now able to change the dates of vacation and the days consumed change accordingly
- Default days of vacation are NOT shown in the vacation request table, instead it shows days consumed
- When creating or drafting a vacation request employee can no longer create multiple identical ones by accidentally or on purpose spamming the submit button

Fixes #442 